### PR TITLE
Added shared schemes to repo

### DIFF
--- a/TweenKit/TweenKit.xcodeproj/xcshareddata/xcschemes/TweenKit-macOS.xcscheme
+++ b/TweenKit/TweenKit.xcodeproj/xcshareddata/xcschemes/TweenKit-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6750B8F21E7C855A00E7AEE2"
+               BlueprintIdentifier = "678408B02502CAD800FEA79B"
                BuildableName = "TweenKit.framework"
-               BlueprintName = "TweenKit"
+               BlueprintName = "TweenKit-macOS"
                ReferencedContainer = "container:TweenKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -28,16 +28,6 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6750B8FB1E7C855A00E7AEE2"
-               BuildableName = "TweenKitTests.xctest"
-               BlueprintName = "TweenKitTests"
-               ReferencedContainer = "container:TweenKit.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction
@@ -50,15 +40,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "6750B8F21E7C855A00E7AEE2"
-            BuildableName = "TweenKit.framework"
-            BlueprintName = "TweenKit"
-            ReferencedContainer = "container:TweenKit.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -69,9 +50,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "6750B8F21E7C855A00E7AEE2"
+            BlueprintIdentifier = "678408B02502CAD800FEA79B"
             BuildableName = "TweenKit.framework"
-            BlueprintName = "TweenKit"
+            BlueprintName = "TweenKit-macOS"
             ReferencedContainer = "container:TweenKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/TweenKit/TweenKit.xcodeproj/xcshareddata/xcschemes/TweenKit-tvOS.xcscheme
+++ b/TweenKit/TweenKit.xcodeproj/xcshareddata/xcschemes/TweenKit-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6750B8F21E7C855A00E7AEE2"
+               BlueprintIdentifier = "67BA923021E373D2006D7022"
                BuildableName = "TweenKit.framework"
-               BlueprintName = "TweenKit"
+               BlueprintName = "TweenKit-tvOS"
                ReferencedContainer = "container:TweenKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -28,16 +28,6 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6750B8FB1E7C855A00E7AEE2"
-               BuildableName = "TweenKitTests.xctest"
-               BlueprintName = "TweenKitTests"
-               ReferencedContainer = "container:TweenKit.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction
@@ -50,15 +40,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "6750B8F21E7C855A00E7AEE2"
-            BuildableName = "TweenKit.framework"
-            BlueprintName = "TweenKit"
-            ReferencedContainer = "container:TweenKit.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -69,9 +50,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "6750B8F21E7C855A00E7AEE2"
+            BlueprintIdentifier = "67BA923021E373D2006D7022"
             BuildableName = "TweenKit.framework"
-            BlueprintName = "TweenKit"
+            BlueprintName = "TweenKit-tvOS"
             ReferencedContainer = "container:TweenKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>


### PR DESCRIPTION
Resolved an issue where Carthage was unable to build for other platforms except for iOS.

Looks like there was a glitch in Xcode and the shared schemes were not in the `xcshareddata` folder. I just re-applied the schemes to be shared and that seems to have resolved it.